### PR TITLE
Fixed namespace issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "edalzell/feeds",
   "description": "Feeds",
-  "type": "statamic-addon",
   "license": "MIT",
   "require": {
     "php": "^7.4"

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,11 +5,10 @@ namespace Edalzell\Feeds;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Statamic\Providers\AddonServiceProvider;
+use Statamic\Statamic;
 
 class ServiceProvider extends AddonServiceProvider
 {
-    public $defer = false;
-
     public function boot()
     {
         parent::boot();
@@ -18,10 +17,12 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../config.php' => config_path('feeds.php'),
         ]);
 
-        $this->registerWebRoutes(function () {
-            collect(config('feeds.types', []))->each(function ($feed, $key) {
-                Route::namespace('\Edalzell\Feeds\Http\Controllers')
-                    ->get($feed['route'], Str::title($key));
+        Statamic::booted(function () {
+            $this->registerWebRoutes(function () {
+                collect(config('feeds.types', []))->each(function ($feed, $key) {
+                    Route::namespace('\Edalzell\Feeds\Http\Controllers')
+                        ->get($feed['route'], Str::title($key));
+                });
             });
         });
     }


### PR DESCRIPTION
The issue was the addon was being loaded before Statamic itself was being loaded which caused issues. Now your routes will be registered after Statamic itself has booted. Fixes #1.

Also went and removed the type from the `composer.json` file, since [beta 31](https://github.com/statamic/cms/releases/tag/v3.0.0-beta.31) it's no longer needed.